### PR TITLE
Jump to line number even if ffap-guesser expands filename

### DIFF
--- a/helm-files.el
+++ b/helm-files.el
@@ -2145,9 +2145,8 @@ Return candidates prefixed with basename of `helm-input' first."
           ((save-match-data
              (and ffap-url-regexp
                   (not (string-match-p ffap-url-regexp str-at-point))
-                  (string-match (concat "\\(" fname-at-point "\\):\\([0-9]+:?\\)")
-                                str-at-point)
-                  (file-equal-p (match-string 1 str-at-point) candidate)))
+                  (string-match ":\\([0-9]+:?\\)" str-at-point)
+                  ))
            (append '(("Find file to line number" . helm-ff-goto-linum))
                    actions))
           ((string-match (image-file-name-regexp) candidate)
@@ -2177,11 +2176,8 @@ e.g \"foo:12\"."
   (let ((linum (with-helm-current-buffer
                  (let ((str (buffer-substring-no-properties
                              (point-at-bol) (point-at-eol))))
-                   (when (string-match
-                          (concat "\\(" (ffap-guesser)
-                                  "\\):\\([0-9]+:?\\)")
-                          str)
-                     (match-string 2 str))))))
+                   (when (string-match ":\\([0-9]+:?\\)" str)
+                     (match-string 1 str))))))
     (find-file candidate)
     (and linum (not (string= linum ""))
          (helm-goto-line (string-to-number linum) t))))


### PR DESCRIPTION
Imagine that helm-ff-guess-ffap-filenames is t, and string under point is "foo.txt:12". It is possible for (ffap-fuesser) to expand "foo.txt" to something like "/some/full/path/that/contains/foo.txt".

Helm will open /some/full/path/that/contains/foo.txt just fine, but it will not jump to line 12, because code in helm-find-files-action-transformer and helm-ff-goto-linum assumes that ffap will never modify or expand filename taken from line under cursor.

None of the other actions in helm-find-files-action-transformer are quite as strict, so I think it is possible to relax the restriction, and this feature is doing just that.

Way to test:

(add-to-list 'ffap-alist '("foo.bar'" . my-ffap-finder))
(defun my-ffap-finder (name)
     (ffap-locate-file
      name nil (ffap-all-subdirs "~/some/dir/that/contains/foo/bar/")))

now put "foo.bar:12" in a buffer somewhere and call helm-find-files and observe that there is no jump to line 12 after open on master branch and there is jump to line 12 with code from this branch.
